### PR TITLE
Fix missing attribute errors with `argparse.SUPPRESS`

### DIFF
--- a/pydantic_argparse_extensible/__init__.py
+++ b/pydantic_argparse_extensible/__init__.py
@@ -128,15 +128,12 @@ class ArgModel(BaseModel):
                 ret[name] = partial[name]
             elif field.annotation is None:  # pragma: no cover
                 # I'm pretty sure this is unreachable, but the type annotations say otherwise.
-                ret[name] = getattr(args, name)
-            elif isinstance(field.annotation, type):
-                # Annotated with a simple type (and not e.g. a union).
-                if issubclass(field.annotation, ArgModel):
-                    ret[name] = field.annotation.from_parsed_args(args)
-                else:
-                    ret[name] = getattr(args, name)
-            else:
-                # Annotated with something complex like a union.
+                raise TypeError(f"Field {cls.__name__}.{name} has no annotation")
+            elif isinstance(field.annotation, type) and issubclass(
+                field.annotation, ArgModel
+            ):
+                ret[name] = field.annotation.from_parsed_args(args)
+            elif hasattr(args, name):
                 ret[name] = getattr(args, name)
         return cls.model_validate(ret)
 

--- a/tests/test_default_missing_attr.py
+++ b/tests/test_default_missing_attr.py
@@ -1,0 +1,36 @@
+import argparse
+from argparse import _ActionsContainer
+
+from pydantic import Field
+
+from pydantic_argparse_extensible import ArgModel
+
+
+class Args(ArgModel):
+    account_ids: list[str] = Field(default_factory=lambda: ["1", "2", "3"])
+
+    @classmethod
+    def update_argparser(
+        cls, parser: "_ActionsContainer", manual: set[str] | None = None
+    ) -> None:
+        parser.add_argument(
+            "--account-id",
+            action="append",
+            dest="account_ids",
+            default=argparse.SUPPRESS,
+        )
+        if manual is None:
+            manual = set()
+        manual.add("account_ids")
+        return super().update_argparser(parser, manual)
+
+
+def test_parse() -> None:
+    args = Args.argparse(args=[])
+    assert args == Args(account_ids=["1", "2", "3"])
+
+    args = Args.argparse(args=["--account-id", "9999"])
+    assert args == Args(account_ids=["9999"])
+
+    args = Args.argparse(args=["--account-id", "9999", "--account-id", "413"])
+    assert args == Args(account_ids=["9999", "413"])


### PR DESCRIPTION
This lets you use `pydantic` field defaults/default factories more reliably.